### PR TITLE
Add `runtests` function for multi-file test execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ $ testrunner demo.jl "(:(@test startswith(inner_func2(), "inner")))"
 
 ### API
 
+#### `runtest`
+
 ```julia
 runtest(filename::AbstractString, patterns, lines=(); topmodule::Module=Main)
 ```
@@ -78,6 +80,14 @@ specified lines.
 
 **Returns:**
 - Test results from the selectively executed tests
+
+#### `runtests`
+
+The package also provides a `runtests` function for advanced use cases like
+selectively running package test cases from `test/runtests.jl`, where
+you need to specify different patterns for different files in a test suite
+that includes multiple files via `include` statements.
+See its docstring for detailed usage.
 
 ### Pattern Types
 


### PR DESCRIPTION
Enables running tests across multiple files with file-specific pattern configurations. Useful for test suites with multiple included files where different patterns need to be applied to different files.