### PR TITLE
pattern-matching: Match `@testset` with custom AbstractTestSet type

### DIFF
--- a/src/TestRunner.jl
+++ b/src/TestRunner.jl
@@ -349,8 +349,15 @@ function matches_pattern(@nospecialize(expr), patterns::Vector{Any})
 end
 
 function matches_named_testset_call(pat::Union{AbstractString,Regex}, @nospecialize ex)
-    MacroTools.@capture(ex, @testset String_ xs__) || return false
-    return pat isa Regex ? occursin(pat, String) : pat == String
+    name = nothing
+    if MacroTools.@capture(ex, @testset name_String xs__)
+        # vanilla form: `@testset "name" body`
+    elseif MacroTools.@capture(ex, @testset Type_Symbol name_String xs__)
+        # custom test set type: `@testset Type "name" body`
+    else
+        return false
+    end
+    return pat isa Regex ? occursin(pat, name) : pat == name
 end
 
 function is_testset_or_test(@nospecialize expr)

--- a/test/test_pattern_matching.jl
+++ b/test/test_pattern_matching.jl
@@ -56,6 +56,29 @@ using JuliaSyntax: JuliaSyntax as JS
         end
     end
 
+    # `@testset CustomTestSet "name" body` is supported by `Test.@testset` for
+    # using a custom `AbstractTestSet` type; it should match by name just like
+    # the vanilla form.
+    @testset "Custom test set type" begin
+        let expr = :(@testset MyTestSet "foo" begin end)
+            @test TestRunner.matches_pattern(expr, Any["foo"])
+            @test !TestRunner.matches_pattern(expr, Any["bar"])
+            @test TestRunner.matches_pattern(expr, Any[r"^fo"])
+        end
+
+        let expr = :(@testset MyTestSet "verbose case" verbose=true begin end)
+            @test TestRunner.matches_pattern(expr, Any["verbose case"])
+        end
+
+        # Loop form (`@testset Type for ... end`) has no string description and
+        # shouldn't match name patterns.
+        let expr = :(@testset MyTestSet for i = 1:3
+                @test i > 0
+            end)
+            @test !TestRunner.matches_pattern(expr, Any["foo"])
+        end
+    end
+
     @testset "Mixed pattern types" begin
         let patterns = Any["arithmetic", r"arith", :(@test add(a_, b_) == c_)]
             @test TestRunner.matches_pattern(:(@testset "arithmetic" begin end), patterns)


### PR DESCRIPTION
`matches_named_testset_call` previously only matched the vanilla `@testset "name" body` form via `MacroTools.@capture(ex, @testset String_ xs__)`. The typed form `@testset Type "name" body` (used to specify a custom `AbstractTestSet` subtype) has the type symbol as the first positional argument, so it was bound to the `String` variable and the subsequent equality check against the requested pattern always failed.

Add a second `@capture` clause for `@testset Type_Symbol name_String xs__` so typed testsets are matched by their string name. Loop forms (`@testset Type for …`) still correctly return `false` since they have no string description.