### PR TITLE
app: Add `--read-stdin` to run tests against piped source

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ julia> runtest("demo.jl", [:(@test startswith(inner_func2(), "inner"))])
 ### `runtest`
 
 ```julia
-runtest(filename::AbstractString, patterns, lines=(); topmodule::Module=Main)
+runtest(filename::AbstractString, patterns;
+        filter_lines=nothing, topmodule::Module=Main, source=nothing)
 ```
 
 Run tests from a file that match the given patterns and/or are on the
@@ -84,6 +85,10 @@ specified lines.
   IDE integration where clicking on a specific test should run only that test, even when multiple
   tests may match the same pattern
 - `topmodule::Module=Main`: Module context for execution (default: `Main`)
+- `source::Union{Nothing,AbstractString}=nothing`: When provided, use this source text for the
+  entry file instead of reading it from disk. `filename` is still used for `@__FILE__`, error
+  messages, and resolving paths of `include`d files. Useful for editor integrations that want
+  to run tests against an unsaved buffer
 
 **Returns:**
 - Test results from the selectively executed tests
@@ -91,7 +96,8 @@ specified lines.
 ### `runtests`
 
 ```julia
-runtests(entryfilename::AbstractString, patterns; filter_lines=nothing, topmodule::Module=Main)
+runtests(entryfilename::AbstractString, patterns;
+         filter_lines=nothing, topmodule::Module=Main, source=nothing)
 ```
 
 The package also provides a `runtests` function for advanced use cases like
@@ -191,6 +197,10 @@ testrunner --help
 
 # Output results in JSON format
 testrunner --json mypkg/runtests.jl "my tests"
+
+# Read source from stdin (e.g. an unsaved editor buffer); the file path is
+# still needed for `@__FILE__` and to resolve any `include`d files
+cat my-edits.jl | testrunner --read-stdin --json mypkg/runtests.jl "my tests"
 ```
 
 Pattern formats:
@@ -205,6 +215,8 @@ Options:
 - `--filter-lines=1,5,10:20` or `-f=1,5,10:20` - Filter to specific lines
 - `--verbose` or `-v` - Show verbose output
 - `--json` - Output results in JSON format for machine-readable test results
+- `--read-stdin` - Read source for the given file path from stdin instead of disk.
+  The path is still used for `@__FILE__`, error messages, and resolving `include`d files
 
 ## Examples
 

--- a/src/TestRunner.jl
+++ b/src/TestRunner.jl
@@ -38,7 +38,7 @@ const errors_and_fails = Dict{Union{Test.Error,Test.Fail},Vector{Any}}()
 include("TestRunnerTestSet.jl")
 
 """
-    runtest(filename::AbstractString, patterns, lines=(); topmodule::Module=Main)
+    runtest(filename::AbstractString, patterns, lines=(); topmodule::Module=Main, source=nothing)
 
 Run tests from a file that match the given patterns and/or are on the specified lines.
 
@@ -57,6 +57,10 @@ function definitions, imports, and struct definitions.
 - `filter_lines=nothing`: Optional collection of line numbers to filter pattern matches.
   When provided, only pattern matches that overlap with these lines will be executed
 - `topmodule::Module=Main`: Module context for execution (default: `Main`)
+- `source::Union{Nothing,AbstractString}=nothing`: When provided, use this source text for
+  the entry file instead of reading it from disk. `filename` is still used for
+  `@__FILE__`, error messages, and resolving paths of `include`d files (which are
+  read from disk as usual)
 
 # Returns
 Test results from the selectively executed tests, compatible with Julia's Test.jl framework.
@@ -93,7 +97,8 @@ runtest("testfile.jl", ["unit tests", r"helper.*", 42])
 """
 function runtest(filename::AbstractString, patterns;
                  filter_lines=nothing,
-                 topmodule::Module=Main)
+                 topmodule::Module=Main,
+                 source::Union{Nothing,AbstractString}=nothing)
     filepath = abspath(filename)
     patterns = Dict{String,Vector{Any}}(filepath => Any[pat for pat in patterns])
     if isnothing(filter_lines)
@@ -105,7 +110,7 @@ function runtest(filename::AbstractString, patterns;
     global current_interpreter
     current_interpreter[] = interp
     empty!(errors_and_fails)
-    _selective_run(interp)
+    _selective_run(interp; source)
 end
 
 """
@@ -173,7 +178,8 @@ runtests("test/runtests.jl",
 """
 function runtests(entryfilename::AbstractString, patterns_for_files;
                   filter_lines_for_files=nothing,
-                  topmodule::Module=Main)
+                  topmodule::Module=Main,
+                  source::Union{Nothing,AbstractString}=nothing)
     patterns = Dict{String,Vector{Any}}()
     for (filepath, pats) in patterns_for_files
         patterns[abspath(filepath)] = Any[pat for pat in pats]
@@ -189,13 +195,18 @@ function runtests(entryfilename::AbstractString, patterns_for_files;
     global current_interpreter
     current_interpreter[] = interp
     empty!(errors_and_fails)
-    _selective_run(interp)
+    _selective_run(interp; source)
 end
 
-function _selective_run(interp::TRInterpreter)
+function _selective_run(interp::TRInterpreter;
+                        source::Union{Nothing,AbstractString}=nothing)
     filename = interp.filename
-    isfile(filename) || throw(SystemError(lazy"opening file \"$filename\"", 2, nothing))
-    toptext = read(filename, String)
+    if source === nothing
+        isfile(filename) || throw(SystemError(lazy"opening file \"$filename\"", 2, nothing))
+        toptext = read(filename, String)
+    else
+        toptext = source
+    end
     stream = JS.ParseStream(toptext)
     JS.parse!(stream; rule=:all)
     isempty(stream.diagnostics) || throw(JS.ParseError(stream))

--- a/src/app.jl
+++ b/src/app.jl
@@ -71,7 +71,7 @@ function (@main)(args::Vector{String})
 
     patterns = String[]
     filename = filter_lines = project = nothing
-    verbose = json_output = false
+    verbose = json_output = read_stdin = false
 
     i = 1
     while i <= length(args)
@@ -100,6 +100,8 @@ function (@main)(args::Vector{String})
             verbose = true
         elseif arg == "--json"
             json_output = true
+        elseif arg == "--read-stdin"
+            read_stdin = true
         elseif startswith(arg, "-") && arg != "-"
             error_print("Unknown option:", arg)
             error_detail_print("Run with --help to see available options")
@@ -132,7 +134,7 @@ function (@main)(args::Vector{String})
     end
 
     # Run tests
-    return runtest_app(filename, parsed_patterns, filter_lines, verbose, project, json_output)
+    return runtest_app(filename, parsed_patterns, filter_lines, verbose, project, json_output, read_stdin)
 end
 
 function print_usage()
@@ -156,6 +158,9 @@ function print_usage()
       -f=1,5,10:20              Short form of --filter-lines
       --verbose, -v             Show verbose output
       --json                    Output results in JSON format
+      --read-stdin              Read source for <path> from stdin instead of disk
+                                (<path> is still used for `@__FILE__`, error
+                                messages, and resolving `include`d files)
       -h, --help                Show this help message
 
     Examples:
@@ -375,7 +380,8 @@ function extract_diagnostics_from_exception(ex::Test.TestSetException)
     return diagnostics
 end
 
-function runtest_internal(filename::String, patterns::Vector{Any}, filter_lines, verbose::Bool, project)
+function runtest_internal(filename::String, patterns::Vector{Any}, filter_lines, verbose::Bool, project,
+                          source::Union{Nothing,String}=nothing)
     # Set `LOAD_PATH` manually: app shim sets limits it by default
     if Base.should_use_main_entrypoint()
         empty!(LOAD_PATH)
@@ -437,13 +443,18 @@ function runtest_internal(filename::String, patterns::Vector{Any}, filter_lines,
 
     topmodule = @something app_runner_module[] Main
     if isempty(patterns)
-        return Test.@testset "$bname" verbose=verbose Base.IncludeInto(topmodule)(filename)
+        if source === nothing
+            return Test.@testset "$bname" verbose=verbose Base.IncludeInto(topmodule)(filename)
+        else
+            return Test.@testset "$bname" verbose=verbose Base.include_string(topmodule, source, filename)
+        end
     else
-        return Test.@testset TestRunnerTestSet "$bname" verbose=verbose runtest(filename, patterns; filter_lines, topmodule)
+        return Test.@testset TestRunnerTestSet "$bname" verbose=verbose runtest(filename, patterns; filter_lines, topmodule, source)
     end
 end
 
-function runtest_json(filename::String, patterns::Vector{Any}, filter_lines, verbose::Bool, project)
+function runtest_json(filename::String, patterns::Vector{Any}, filter_lines, verbose::Bool, project,
+                      source::Union{Nothing,String}=nothing)
     # Redirect stdout to capture ALL output (including info_print, header_print, etc.)
     original_stdout = stdout
     (rd, wr) = redirect_stdout()
@@ -452,7 +463,7 @@ function runtest_json(filename::String, patterns::Vector{Any}, filter_lines, ver
     local diagnostics::Vector{TestRunnerDiagnostic} = TestRunnerDiagnostic[]
     start_time = time()
     try
-        result = runtest_internal(filename, patterns, filter_lines, verbose, project)
+        result = runtest_internal(filename, patterns, filter_lines, verbose, project, source)
         counts = Test.get_test_counts(result)
         n_passed = counts.passes + counts.cumulative_passes
         n_failed = counts.fails + counts.cumulative_fails
@@ -483,15 +494,16 @@ function runtest_json(filename::String, patterns::Vector{Any}, filter_lines, ver
     end
 end
 
-function runtest_app(filename::String, patterns::Vector{Any}, filter_lines, verbose::Bool, project, json_output::Bool)
-    if !isfile(filename)
+function runtest_app(filename::String, patterns::Vector{Any}, filter_lines, verbose::Bool, project, json_output::Bool, read_stdin::Bool=false)
+    source = read_stdin ? read(stdin, String) : nothing
+    if source === nothing && !isfile(filename)
         error_print("File not found:", filename)
         return 1
     end
     if json_output
-        return runtest_json(filename, patterns, filter_lines, verbose, project)
+        return runtest_json(filename, patterns, filter_lines, verbose, project, source)
     else
-        runtest_internal(filename, patterns, filter_lines, verbose, project)
+        runtest_internal(filename, patterns, filter_lines, verbose, project, source)
         return 0
     end
 end

--- a/test/test_json_output.jl
+++ b/test/test_json_output.jl
@@ -37,14 +37,18 @@ function with_failing_test_file(tester)
     end
 end
 
-function run_testrunner_process(args)
+function run_testrunner_process(args; stdin_input::Union{Nothing,AbstractString}=nothing)
     project = dirname(dirname(@__DIR__))  # Get TestRunner project directory
     cmd = `$(Base.julia_cmd()) --startup-file=no --project=$project -e "using TestRunner; exit(TestRunner.main(ARGS))" -- $args`
 
     mktemp() do out_path, _
         mktemp() do err_path, _
-            # Run the command with output redirected to files
-            proc = run(pipeline(cmd, stdout=out_path, stderr=err_path), wait=false)
+            pipe = if stdin_input === nothing
+                pipeline(cmd, stdout=out_path, stderr=err_path)
+            else
+                pipeline(cmd, stdin=IOBuffer(stdin_input), stdout=out_path, stderr=err_path)
+            end
+            proc = run(pipe, wait=false)
             wait(proc)
 
             return (
@@ -116,6 +120,76 @@ with_failing_test_file() do testfile
     @test stats.n_passed == stats.n_errored == stats.n_broken == 0
     @test stats.duration > 0
     @test !isempty(json_result.diagnostics)
+end
+
+@testset "--read-stdin" begin
+    # Pass source via stdin; file path is still required for `@__FILE__` etc.
+    let source = """
+        using Test
+        @testset "stdin test" begin
+            @test 1 + 1 == 2
+        end
+        """
+        with_simple_passing_test_file() do testfile
+            result = run_testrunner_process(["--json", "--read-stdin", testfile];
+                                            stdin_input=source)
+            @test result.exitcode == 0
+            @test isempty(result.stderr)
+            json_result = JSON.parse(result.stdout, TestRunnerResult)
+            stats = json_result.stats
+            @test stats.n_passed == 1
+            @test stats.n_failed == stats.n_errored == stats.n_broken == 0
+        end
+    end
+
+    # Stdin source overrides on-disk content: testset name only exists in stdin
+    with_simple_passing_test_file() do testfile
+        source = """
+        using Test
+        @testset "stdin only" begin
+            @test true
+        end
+        """
+        result = run_testrunner_process(["--json", "--read-stdin", testfile, "stdin only"];
+                                        stdin_input=source)
+        @test result.exitcode == 0
+        json_result = JSON.parse(result.stdout, TestRunnerResult)
+        @test json_result.stats.n_passed == 1
+    end
+
+    # `--read-stdin` works even when the file does not exist on disk
+    let source = """
+        using Test
+        @testset "no file" begin
+            @test 1 == 1
+        end
+        """
+        nonexistent = joinpath(mktempdir(), "ghost.jl")
+        result = run_testrunner_process(["--json", "--read-stdin", nonexistent];
+                                        stdin_input=source)
+        @test result.exitcode == 0
+        json_result = JSON.parse(result.stdout, TestRunnerResult)
+        @test json_result.stats.n_passed == 1
+    end
+
+    # `--read-stdin` plus `--filter-lines` matches a testset on a stdin-defined line
+    with_simple_passing_test_file() do testfile
+        source = """
+        using Test
+        @testset "first" begin
+            @test 1 == 1
+        end
+        @testset "second" begin
+            @test 2 == 2
+        end
+        """
+        result = run_testrunner_process(
+            ["--json", "--read-stdin", testfile, "second", "--filter-lines=5"];
+            stdin_input=source)
+        @test result.exitcode == 0
+        json_result = JSON.parse(result.stdout, TestRunnerResult)
+        @test json_result.stats.n_passed == 1
+    end
 end
 
 end # module test_json_output


### PR DESCRIPTION
Add a `source::Union{Nothing,AbstractString}=nothing` keyword argument to `runtest` / `runtests` (and the internal `_selective_run`). When provided, the entry file's source text is read from `source` instead of disk, while `filename` continues to drive `@__FILE__`, error messages, and resolution of `include`d files (which still load from disk).

Expose this through a new `--read-stdin` CLI flag: when set, the app reads stdin into the new `source` kwarg. The pattern-less path uses `Base.include_string` instead of `Base.IncludeInto` so that the filename meta is preserved.

This is primarily aimed at editor integrations (e.g. JETLS) that want to run tests against an unsaved buffer without first writing it to disk.