### PR TITLE
runtest: Support LoweredCodeUtils v3.6 add_active_gotos! API

### DIFF
--- a/src/TestRunner.jl
+++ b/src/TestRunner.jl
@@ -445,7 +445,14 @@ function select_dependencies!(concretized::BitVector, src::CodeInfo, edges, cl)
         changed |= LCU.add_control_flow!(concretized, src, cfg, postdomtree)
     end
 
-    LCU.add_active_gotos!(concretized, src, cfg, postdomtree)
+    # LCU v3.6+ requires SelectiveEvalController for add_active_gotos!.
+    if isdefined(LCU, :SelectiveEvalController)
+        LCU.add_active_gotos!(
+            concretized, src, cfg, postdomtree, LCU.SelectiveEvalController(),
+        )
+    else
+        LCU.add_active_gotos!(concretized, src, cfg, postdomtree)
+    end
 end
 
 # Add statements that use SSA values produced by already selected statements


### PR DESCRIPTION
## Summary
- LoweredCodeUtils v3.6 changed `add_active_gotos!` to require
  an additional `SelectiveEvalController` argument, which broke
  precompilation as reported in #28.
- Branch on `isdefined(LCU, :SelectiveEvalController)` so both
  the pre-v3.6 and v3.6+ APIs are supported without raising the
  `[compat]` lower bound for LoweredCodeUtils.

## Test plan
- `Pkg.test()` passes with LoweredCodeUtils v3.5.3 (228 passed, 5 broken)
- `Pkg.test()` passes with LoweredCodeUtils v3.6.2 (228 passed, 5 broken)

Fixes #28